### PR TITLE
Added placeholder for license (required field)

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -58,6 +58,13 @@
   "version": "1.1",
   "availability": "available",
   "privacy": "Private",
+  "licenses": [
+    {
+      "@id": "https://w3id.org/dats/schema/license_schema.json",
+      "@type": "License",
+      "name": "to be determined"
+    }
+  ],
   "distributions": [
     {
     "@id": "http://json-schema.org/draft-04/schema",


### PR DESCRIPTION
Hi @bpinsard and @pbellec, turns out that license is a required field in the CONP metadata. I added a placeholder for it, let me know if you have anything else to suggest.